### PR TITLE
utils: fix url generation for unicode + release: v1.0.0a3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,6 @@
 Changes
 =======
 
-Version 1.0.0a2 (released 2018-04-09)
+Version 1.0.0a3 (released 2018-04-17)
 
 - Initial public release.

--- a/invenio_iiif/config.py
+++ b/invenio_iiif/config.py
@@ -15,7 +15,6 @@ IIIF_UI_URL = '/api{}'.format(IIIF_API_PREFIX)
 """URL to IIIF API endpoint (allow hostname)."""
 
 IIIF_PREVIEWER_PARAMS = {
-    'image_format': 'jpg',
     'size': '750,'
 }
 """Parameters for IIIF image previewer extension."""

--- a/invenio_iiif/previewer.py
+++ b/invenio_iiif/previewer.py
@@ -10,6 +10,8 @@
 
 from __future__ import absolute_import, print_function
 
+from copy import deepcopy
+
 from flask import Blueprint, current_app, render_template
 
 from .utils import ui_iiif_image_url
@@ -32,11 +34,15 @@ def can_preview(file):
 
 def preview(file):
     """Render appropriate template with embed flag."""
+    params = deepcopy(current_app.config['IIIF_PREVIEWER_PARAMS'])
+    if 'image_format' not in params:
+        params['image_format'] = \
+            'png' if file.has_extensions('.png') else 'jpg'
     return render_template(
         current_app.config['IIIF_PREVIEW_TEMPLATE'],
         file=file,
         file_url=ui_iiif_image_url(
             file.file,
-            **current_app.config['IIIF_PREVIEWER_PARAMS']
+            **params
         )
     )

--- a/invenio_iiif/utils.py
+++ b/invenio_iiif/utils.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, print_function
 
 from flask import current_app
 from invenio_files_rest.models import ObjectVersion
+from six.moves.urllib_parse import quote
 
 
 def iiif_image_key(obj):
@@ -24,7 +25,7 @@ def iiif_image_key(obj):
         bucket_id = obj.get('bucket')
         version_id = obj.get('version_id')
         key = obj.get('key')
-    return '{}:{}:{}'.format(
+    return u'{}:{}:{}'.format(
         bucket_id,
         version_id,
         key,
@@ -34,11 +35,12 @@ def iiif_image_key(obj):
 def ui_iiif_image_url(obj, version='v2', region='full', size='full',
                       rotation=0, quality='default', image_format='png'):
     """Generate IIIF image URL from the UI application."""
-    return '{prefix}{version}/{identifier}/{region}/{size}/{rotation}/' \
-        '{quality}.{image_format}'.format(
+    return u'{prefix}{version}/{identifier}/{region}/{size}/{rotation}/' \
+        u'{quality}.{image_format}'.format(
             prefix=current_app.config['IIIF_UI_URL'],
             version=version,
-            identifier=iiif_image_key(obj),
+            identifier=quote(
+                iiif_image_key(obj).encode('utf8'), safe=':'),
             region=region,
             size=size,
             rotation=rotation,

--- a/invenio_iiif/version.py
+++ b/invenio_iiif/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.0.0a2'
+__version__ = '1.0.0a3'

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,12 @@ setup_requires = [
 install_requires = [
     'Flask>=0.11.1',
     'Flask-CeleryExt>=0.3.0',
-    'Flask-IIIF>=0.3.2',
+    'Flask-IIIF>=0.4.0',
     # FIXME: Invenio-Files-REST should specify Invenio-Access as requirement.
     'invenio-access>=1.0.0',
     'invenio-files-rest>=1.0.0a9',
     'invenio-records-files>=1.0.0a9',
+    'six>=1.11.0',
     'Wand>=0.4.4',
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,7 @@ def image_object(database, location, image_path):
 
     with open(image_path, 'rb') as fp:
         obj = ObjectVersion.create(
-            bucket, u'test-ünicode.jpg', stream=fp, size=getsize(image_path)
+            bucket, u'test-ünicode.png', stream=fp, size=getsize(image_path)
         )
     database.session.commit()
     return obj

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def image_path():
 
     The test image was downloaded from Flickr and marked as public domain.
     """
-    return join(dirname(__file__), 'image-public-domain.jpg')
+    return join(dirname(__file__), u'image-public-domain.jpg')
 
 
 @pytest.fixture(scope='module')
@@ -112,7 +112,7 @@ def image_object(database, location, image_path):
 
     with open(image_path, 'rb') as fp:
         obj = ObjectVersion.create(
-            bucket, 'test.jpg', stream=fp, size=getsize(image_path)
+            bucket, u'test-ünicode.jpg', stream=fp, size=getsize(image_path)
         )
     database.session.commit()
     return obj
@@ -121,7 +121,7 @@ def image_object(database, location, image_path):
 @pytest.fixture(scope='module')
 def image_uuid(image_object):
     """Get image UUID (Flask-IIIF term, not actual an UUID)."""
-    return '{}:{}:{}'.format(
+    return u'{}:{}:{}'.format(
         image_object.bucket_id,
         image_object.version_id,
         image_object.key

--- a/tests/test_previewer.py
+++ b/tests/test_previewer.py
@@ -41,3 +41,5 @@ def test_preview(image_object):
     """Test preview."""
     assert ui_iiif_image_url(image_object, size='750,', image_format='jpg') \
         in preview(MockPreviewFile(image_object, 'jpg'))
+    assert ui_iiif_image_url(image_object, size='750,', image_format='png') \
+        in preview(MockPreviewFile(image_object, 'png'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, print_function
 
 import pytest
 from flask_iiif import iiif_image_url
+from six.moves.urllib.parse import quote
 
 from invenio_iiif.utils import iiif_image_key, ui_iiif_image_url
 
@@ -27,7 +28,7 @@ def app_config(app_config):
 
 def test_iiif_image_key(image_object):
     """Test retrieval of image."""
-    key = '{}:{}:{}'.format(
+    key = u'{}:{}:{}'.format(
         image_object.bucket_id,
         image_object.version_id,
         image_object.key,


### PR DESCRIPTION
* Properly generates URLs containing unicode characters. (closes #6)