### PR TITLE
setup: removed FIXME from install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ install_requires = [
     'Flask>=0.11.1',
     'Flask-CeleryExt>=0.3.1',
     'Flask-IIIF>=0.4.0',
-    # FIXME: Invenio-Files-REST should specify Invenio-Access as requirement.
     'invenio-access>=1.0.0',
     'invenio-files-rest>=1.0.0a23',
     'invenio-records-files>=1.0.0a9',


### PR DESCRIPTION
Removed the following note `FIXME: Invenio-Files-REST should specify Invenio-Access as requirement.` which will not be implemented.

closes #14