### PR TITLE
Make package ready for Flask 2

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,3 +14,4 @@ Authors
 - Lars Holm Nielsen
 - Nikos Filippakis
 - Sebastian Witowski
+- Maximilian Moser

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.2.0 (released 2021-10-20)
+
+- Unpin Flask.
+
 Version 1.1.1 (released 2021-05-27)
 
 - Make API decorator and image opener handler configurable.

--- a/invenio_iiif/utils.py
+++ b/invenio_iiif/utils.py
@@ -10,9 +10,10 @@
 
 from __future__ import absolute_import, print_function
 
+from urllib.parse import quote
+
 from flask import current_app
 from invenio_files_rest.models import ObjectVersion
-from six.moves.urllib_parse import quote
 
 
 def iiif_image_key(obj):

--- a/invenio_iiif/version.py
+++ b/invenio_iiif/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.1'
+__version__ = '1.2.0'

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
-    'urllib3>=1.21.1,<1.25',
     'invenio-db[versioning,postgresql]>=1.0.9',
     'pytest-invenio>=1.4.2',
 ]

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2018 CERN.
+# Copyright (C) 2021 TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -37,7 +38,6 @@ setup_requires = [
 ]
 
 install_requires = [
-    'Flask>=1.1,<2.0',
     'Flask-IIIF>=0.6.1',
     'invenio-access>=1.4.2',
     'invenio-base>=1.2.4',

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ setup_requires = [
 install_requires = [
     'Flask-IIIF>=0.6.1',
     'invenio-access>=1.4.2',
-    'invenio-base>=1.2.4',
-    'invenio-celery>=1.2.2',
-    'invenio-files-rest>=1.0.0',
+    'invenio-base>=1.2.5',
+    'invenio-celery>=1.2.3',
+    'invenio-files-rest>=1.3.0',
     'invenio-records-files>=1.0.0',
     'Wand>=0.4.4',
 ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import, print_function
 
 import pytest
 from flask_iiif import iiif_image_url
-from six.moves.urllib.parse import quote
 
 from invenio_iiif.utils import iiif_image_key, ui_iiif_image_url
 


### PR DESCRIPTION
Requires the changes from the following PRs:
* https://github.com/inveniosoftware/invenio-base/pull/160
* https://github.com/inveniosoftware/invenio-accounts/pull/377
* https://github.com/inveniosoftware/invenio-assets/pull/141
* https://github.com/inveniosoftware/invenio-rest/pull/126
* https://github.com/inveniosoftware/invenio-files-rest/pull/265 (for the `use_2to3` issue with setuptools 58)